### PR TITLE
Add Verbose Switch for Get-CrmConnection and Update to Solution Import Result Validation

### DIFF
--- a/CRM365/Xrm.Framework.CI/Xrm.Framework.CI.PowerShell.Scripts/DeployPackage.ps1
+++ b/CRM365/Xrm.Framework.CI/Xrm.Framework.CI.PowerShell.Scripts/DeployPackage.ps1
@@ -47,8 +47,8 @@ $Cred = New-Object System.Management.Automation.PSCredential ($Username, $SecPas
 
 switch($DeploymentType)
 {
-    "Onpremises" { $CRMConn = Get-CrmConnection -ServerUrl $ServerUrl -OrganizationName $OrganizationName -Credential $Cred }
-	"Online" { $CRMConn = Get-CrmConnection -Credential $Cred -DeploymentRegion $DeploymentRegion –OnlineType $OnlineType –OrganizationName $OrganizationName }
+    "Onpremises" { $CRMConn = Get-CrmConnection -ServerUrl $ServerUrl -OrganizationName $OrganizationName -Credential $Cred  -Verbose}
+	"Online" { $CRMConn = Get-CrmConnection -Credential $Cred -DeploymentRegion $DeploymentRegion –OnlineType $OnlineType –OrganizationName $OrganizationName -Verbose}
 }
 
 #Deploy Package

--- a/CRM365/Xrm.Framework.CI/Xrm.Framework.CI.PowerShell.Scripts/ImportSolution.ps1
+++ b/CRM365/Xrm.Framework.CI/Xrm.Framework.CI.PowerShell.Scripts/ImportSolution.ps1
@@ -91,16 +91,38 @@ if ($override -or ($solution -eq $null) -or ($solution.Version -ne $solutionInfo
     Write-Verbose "Import Error Text: $importErrorText"
     Write-Verbose $importJob.Data
 
-    if (($importResult -ne "success") -or ($importProgress -ne 100))
+    	if ($importResult -ne "success")
     {
         throw "Import Failed"
     }
 
-    $solution = Get-XrmSolution -ConnectionString $CrmConnectionString -UniqueSolutionName $solutionInfo.UniqueName
+	#parse the importexportxml and look for result notes with result="failure"
+	$importFailed = $false
+	$importjobXml = [xml]$importJob.Data
+	$failureNodes = $importjobXml.SelectNodes("//*[@result='failure']")
 
-    if ($solution.Version -ne $solutionInfo.Version)
+	foreach ($failureNode in $failureNodes){
+		$componentName = $failureNode.ParentNode.Attributes['name'].Value
+		$errorText = $failureNode.Attributes['errortext'].Value
+		Write-Host "Component Import Failure: '$componentName' failed with error: '$errorText'"
+		$importFailed = $true
+	}
+		
+	if ($importFailed -eq $true)
+	{	
+		throw "The Solution Import failed because one or more components with a result of 'failure' were found. For detals, check the Diagnostics for this build or the solution import log file in the logs subfolder of the Drop folder."
+	}
+	else
+	{
+		Write-Host "The import result of all components is 'success'."
+	}
+	#end parse the importexportxml and look for result notes with result="failure"
+    
+	$solution = Get-XrmSolution -ConnectionString $CrmConnectionString -UniqueSolutionName $solutionInfo.UniqueName
+
+    if ($solution.Version -ne $solutionInfo.Version) 
     {
-        throw "Import Failed"
+        throw "Import Failed. Check the solution import log file in the logs subfolder of the Drop folder."
     }
     else
     {


### PR DESCRIPTION
Added verbose switch to Get-CrmConnection. Based on recommendation from Microsoft, it is necessary to pass the -Verbose switch to the call to the Get-CrmConnection cmdlet, not the Import-CrmPackage cmdlet. This causes detailed output to be added to the Package Deployer log file. With this switch, you should see the following lines in VSTS log file:
![image](https://cloud.githubusercontent.com/assets/16546265/22799725/d273e028-eed4-11e6-8a9a-e637e96e8d5c.png)
When the deployment step is included in a Build definition, it is possible to copy this log file to build artifacts. I'm still looking for ways to expose the content of this file from a Release definition that runs on the Hosted build agent. 