### PR TITLE
Added option to only export solution if it's a higher version

### DIFF
--- a/CRM365/Xrm.Framework.CI/Xrm.Framework.CI.PowerShell.Scripts/ExportSolution.ps1
+++ b/CRM365/Xrm.Framework.CI/Xrm.Framework.CI.PowerShell.Scripts/ExportSolution.ps1
@@ -3,27 +3,28 @@
 #
 
 param(
-[string]$CrmConnectionString,
-[string]$SolutionName,
-[bool]$ExportManaged,
-[bool]$ExportUnmanaged = $true,
-[string]$TargetVersion,
-[string]$ExportSolutionOutputPath,
-[bool]$UpdateVersion,
-[string]$RequiredVersion,
-[int]$Timeout,
-[bool]$ExportIncludeVersionInSolutionName,
-[bool]$ExportAutoNumberingSettings,
-[bool]$ExportCalendarSettings,
-[bool]$ExportCustomizationSettings,
-[bool]$ExportEmailTrackingSettings,
-[bool]$ExportExternalApplications,
-[bool]$ExportGeneralSettings,
-[bool]$ExportIsvConfig,
-[bool]$ExportMarketingSettings,
-[bool]$ExportOutlookSynchronizationSettings,
-[bool]$ExportRelationshipRoles,
-[bool]$ExportSales
+    [string]$CrmConnectionString,
+    [string]$SolutionName,
+    [bool]$ExportManaged,
+    [bool]$ExportUnmanaged = $true,
+    [string]$TargetVersion,
+    [string]$ExportSolutionOutputPath,
+    [bool]$UpdateVersion,
+    [string]$RequiredVersion,
+    [int]$Timeout,
+    [bool]$ExportIncludeVersionInSolutionName,
+    [bool]$ExportAutoNumberingSettings,
+    [bool]$ExportCalendarSettings,
+    [bool]$ExportCustomizationSettings,
+    [bool]$ExportEmailTrackingSettings,
+    [bool]$ExportExternalApplications,
+    [bool]$ExportGeneralSettings,
+    [bool]$ExportIsvConfig,
+    [bool]$ExportMarketingSettings,
+    [bool]$ExportOutlookSynchronizationSettings,
+    [bool]$ExportRelationshipRoles,
+    [bool]$ExportSales,
+    [switch]$OnlyExportIfNewer
 )
 
 $ErrorActionPreference = "Stop"
@@ -41,6 +42,7 @@ Write-Verbose "UpdateVersion = $UpdateVersion"
 Write-Verbose "RequiredVersion = $RequiredVersion"
 Write-Verbose "Timeout = $Timeout"
 Write-Verbose "ExportIncludeVersionInSolutionName = $ExportIncludeVersionInSolutionName"
+Write-Verbose "OnlyExportIfNewer = $OnlyExportIfNewer"
 Write-Verbose "ExportAutoNumberingSettings = $ExportAutoNumberingSettings"
 Write-Verbose "ExportCalendarSettings = $ExportCalendarSettings"
 Write-Verbose "ExportCustomizationSettings = $ExportCustomizationSettings"
@@ -66,9 +68,9 @@ Write-Verbose "Imported CIToolkit"
 #Update Version
 if ($UpdateVersion)
 {
-	Write-Host "Updating Solution Version to $RequiredVersion"
-	Set-XrmSolutionVersion -ConnectionString $CrmConnectionString -SolutionName $SolutionName -Version $RequiredVersion
-	Write-Host "Solution Version Updated"
+    Write-Host "Updating Solution Version to $RequiredVersion"
+    Set-XrmSolutionVersion -ConnectionString $CrmConnectionString -SolutionName $SolutionName -Version $RequiredVersion
+    Write-Host "Solution Version Updated"
 }
 
 #Solution Export
@@ -76,22 +78,109 @@ if ($UpdateVersion)
 $exportManagedFile
 $exportUnmanagedFile
 
+Function Test-SolutionIsNewer {
+    param(
+        [string]$ConnectionString,
+        [string]$SolutionName,
+        [string]$OutputPath,
+        [switch]$IsManaged
+    )
+    
+    Write-Verbose "Test-SolutionIsNewer"
+    Write-Verbose "ConnectionString = $ConnectionString"
+    Write-Verbose "SolutionName = $SolutionName"
+    Write-Verbose "OutputPath = $OutputPath"
+    Write-Verbose "IsManaged = $IsManaged"
+
+    $sourceSolutionInfo = Get-XrmSolution -ConnectionString $ConnectionString -UniqueSolutionName $SolutionName
+    $solutionVersion = $sourceSolutionInfo.Version
+
+    $managed = ""
+    if ($IsManaged) {
+        $managed = "_managed"
+    }
+
+    # First, check for versioned file names, e.g. Solution_1.0.0.0.zip or Solution_1.0.0.0_managed.zip
+    $versionedFilename = "$OutputPath\$($SolutionName)_*$managed.zip"
+
+    Write-Verbose "Checking for versioned files in `"$OutputPath`", and taking the highest version if there are multiple files"
+    $newestVersionedFilename = Get-ChildItem $versionedFilename `
+		| Where-Object { $_.Name -Match "$($SolutionName)_[0-9]+_[0-9]+_[0-9]+_[0-9]+$managed\.zip$" } `
+		| Sort-Object { [version](([regex]"([0-9]+_[0-9]+_[0-9]+_[0-9]+)$managed\.zip$").Matches($_).Groups[1].Value -replace "_", ".") } -Descending `
+		| Select-Object -ExpandProperty Name -First 1
+
+    if ($newestVersionedFilename -ne $null) {
+        Write-Verbose "File with highest version in `"$OutputPath`" is `"$newestVersionedFilename`""
+
+        $currentFileVersion = (([regex]"([0-9]+_[0-9]+_[0-9]+_[0-9]+)$managed\.zip$").Matches($newestVersionedFilename).Groups[1].Value -replace "_", ".")
+        Write-Verbose "Version from file is $currentFileVersion"
+
+        if ([Version]$solutionVersion -le [version]$currentFileVersion) {
+            Write-Output $true
+            Write-Host "Skipped exporting $(if ($IsManaged) { "managed" } else { "unmanaged" }) solution because the source version `"$solutionVersion`" is not higher then the current version `"$currentFileVersion`""
+            return
+        } else {
+            Write-Verbose "New version `"$solutionVersion`" is higher"
+        }
+    } else {
+        Write-Verbose "No versioned file exists in `"$OutputPath`""
+    }
+    
+    # Second, check for unversioned file names, e.g. Solution.zip or Solution_managed.zip
+    $unversionedFilename = "$OutputPath\$SolutionName$managed.zip"
+
+    Write-Verbose "Testing if file `"$unversionedFilename`" exists"
+    if (Test-Path $unversionedFilename) {
+        Write-Verbose "File `"$unversionedFilename`" exists, reading version info from file"
+        $currentSolutionInfo = Get-XrmSolutionInfoFromZip -SolutionFilePath $unversionedFilename
+        Write-Verbose "Version from file is $($currentSolutionInfo.Version)"
+        
+        if ([version]$solutionVersion -le [version]$currentSolutionInfo.Version) {
+            Write-Output $true
+            Write-Host "Skipped exporting $(if ($IsManaged) { "managed" } else { "unmanaged" }) solution because the source version `"$solutionVersion`" is not higher then the current version `"$($currentSolutionInfo.Version)`""
+            return
+        }
+
+        Write-Verbose "Newer version `"$solutionVersion`" is higher"
+    } else {
+        Write-Verbose "File `"$unversionedFilename`" doesn't exists"
+    }
+
+    Write-Output $false
+}
+
 if ($ExportUnmanaged)
 {
-    Write-Host "Exporting Unmanaged Solution"
-        
-    $exportUnmanagedFile = Export-XrmSolution -ConnectionString $CrmConnectionString -UniqueSolutionName $SolutionName -OutputFolder $ExportSolutionOutputPath -Managed $false -TargetVersion $TargetVersion -IncludeVersionInName $ExportIncludeVersionInSolutionName -ExportAutoNumberingSettings $ExportAutoNumberingSettings -ExportCalendarSettings $ExportCalendarSettings -ExportCustomizationSettings $ExportCustomizationSettings -ExportEmailTrackingSettings $ExportEmailTrackingSettings -ExportExternalApplications $ExportExternalApplications -ExportGeneralSettings $ExportGeneralSettings -ExportMarketingSettings $ExportMarketingSettings -ExportOutlookSynchronizationSettings $ExportOutlookSynchronizationSettings -ExportIsvConfig $ExportIsvConfig -ExportRelationshipRoles $ExportRelationshipRoles -ExportSales $ExportSales -Timeout $Timeout
-        
-    Write-Host "UnManaged Solution Exported $ExportSolutionOutputPath\$exportUnmanagedFile"
+    $skipExport = $false;
+    
+    if ($OnlyExportIfNewer) {
+        $skipExport = Test-SolutionIsNewer -ConnectionString $CrmConnectionString -SolutionName $SolutionName -OutputPath $ExportSolutionOutputPath
+    }
+
+    if (-not $skipExport) {
+        Write-Host "Exporting Unmanaged Solution"
+
+        $exportUnmanagedFile = Export-XrmSolution -ConnectionString $CrmConnectionString -UniqueSolutionName $SolutionName -OutputFolder $ExportSolutionOutputPath -Managed $false -TargetVersion $TargetVersion -IncludeVersionInName $ExportIncludeVersionInSolutionName -ExportAutoNumberingSettings $ExportAutoNumberingSettings -ExportCalendarSettings $ExportCalendarSettings -ExportCustomizationSettings $ExportCustomizationSettings -ExportEmailTrackingSettings $ExportEmailTrackingSettings -ExportExternalApplications $ExportExternalApplications -ExportGeneralSettings $ExportGeneralSettings -ExportMarketingSettings $ExportMarketingSettings -ExportOutlookSynchronizationSettings $ExportOutlookSynchronizationSettings -ExportIsvConfig $ExportIsvConfig -ExportRelationshipRoles $ExportRelationshipRoles -ExportSales $ExportSales -Timeout $Timeout
+
+        Write-Host "UnManaged Solution Exported $ExportSolutionOutputPath\$exportUnmanagedFile"
+    }
 }
 
 if ($ExportManaged)
 {
-    Write-Host "Exporting Managed Solution"
-        
-    $exportmanagedFile = Export-XrmSolution -ConnectionString $CrmConnectionString -UniqueSolutionName $SolutionName -OutputFolder $ExportSolutionOutputPath -Managed $true -TargetVersion $TargetVersion -IncludeVersionInName $ExportIncludeVersionInSolutionName -ExportAutoNumberingSettings $ExportAutoNumberingSettings -ExportCalendarSettings $ExportCalendarSettings -ExportCustomizationSettings $ExportCustomizationSettings -ExportEmailTrackingSettings $ExportEmailTrackingSettings -ExportExternalApplications $ExportExternalApplications -ExportGeneralSettings $ExportGeneralSettings -ExportMarketingSettings $ExportMarketingSettings -ExportOutlookSynchronizationSettings $ExportOutlookSynchronizationSettings -ExportIsvConfig $ExportIsvConfig -ExportRelationshipRoles $ExportRelationshipRoles -ExportSales $ExportSales -Timeout $Timeout
+    $skipExport = $false;
     
-    Write-Host "Managed Solution Exported $ExportSolutionOutputPath\$exportmanagedFile"
+    if ($OnlyExportIfNewer) {
+        $skipExport = Test-SolutionIsNewer -ConnectionString $CrmConnectionString -SolutionName $SolutionName -OutputPath $ExportSolutionOutputPath -IsManaged
+    }
+
+    if (-not $skipExport) {
+        Write-Host "Exporting Managed Solution"
+            
+        $exportmanagedFile = Export-XrmSolution -ConnectionString $CrmConnectionString -UniqueSolutionName $SolutionName -OutputFolder $ExportSolutionOutputPath -Managed $true -TargetVersion $TargetVersion -IncludeVersionInName $ExportIncludeVersionInSolutionName -ExportAutoNumberingSettings $ExportAutoNumberingSettings -ExportCalendarSettings $ExportCalendarSettings -ExportCustomizationSettings $ExportCustomizationSettings -ExportEmailTrackingSettings $ExportEmailTrackingSettings -ExportExternalApplications $ExportExternalApplications -ExportGeneralSettings $ExportGeneralSettings -ExportMarketingSettings $ExportMarketingSettings -ExportOutlookSynchronizationSettings $ExportOutlookSynchronizationSettings -ExportIsvConfig $ExportIsvConfig -ExportRelationshipRoles $ExportRelationshipRoles -ExportSales $ExportSales -Timeout $Timeout
+        
+        Write-Host "Managed Solution Exported $ExportSolutionOutputPath\$exportmanagedFile"
+    }
 }
 
 Write-Verbose 'Leaving ExportSolution.ps1'

--- a/CRM365/Xrm.Framework.CI/Xrm.Framework.CI.VSTS.BuildTasks/Extension/vss-extension.json
+++ b/CRM365/Xrm.Framework.CI/Xrm.Framework.CI.VSTS.BuildTasks/Extension/vss-extension.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "xrm-ci-framework-build-tasks",
   "name": "Dynamics CRM Build Tools",
-  "version": "8.0.14",
+  "version": "8.0.16",
   "publisher": "WaelHamze",
   "targets": [
     {

--- a/CRM365/Xrm.Framework.CI/Xrm.Framework.CI.VSTS.BuildTasks/Tasks/MSCRMExportSolution/MSCRMExportSolution.ps1
+++ b/CRM365/Xrm.Framework.CI/Xrm.Framework.CI.VSTS.BuildTasks/Tasks/MSCRMExportSolution/MSCRMExportSolution.ps1
@@ -15,6 +15,7 @@ $includeVersionInSolutionFile = Get-VstsInput -Name includeVersionInSolutionFile
 $targetVersion = Get-VstsInput -Name targetVersion
 $updateVersion = Get-VstsInput -Name updateVersion -AsBool
 $includeVersionInSolutionFile = Get-VstsInput -Name includeVersionInSolutionFile -AsBool
+$onlyExportIfNewer = Get-VstsInput -Name onlyExportIfNewer -AsBool
 $outputPath = Get-VstsInput -Name outputPath -Require
 $crmConnectionTimeout = Get-VstsInput -Name crmConnectionTimeout -Require -AsInt
 $exportAutoNumberingSettings = Get-VstsInput -Name exportAutoNumberingSettings -AsBool
@@ -43,12 +44,13 @@ Write-Verbose "includeVersionInSolutionFile = $includeVersionInSolutionFile"
 Write-Verbose "targetVersion = $targetVersion"
 Write-Verbose "updateVersion = $updateVersion"
 Write-Verbose "includeVersionInSolutionFile = $includeVersionInSolutionFile"
+Write-Verbose "onlyExportIfNewer = $onlyExportIfNewer"
 Write-Verbose "outputPath = $outputPath"
 Write-Verbose "crmConnectionTimeout = $crmConnectionTimeout"
 Write-Verbose "exportAutoNumberingSettings = $exportAutoNumberingSettings"
 Write-Verbose "exportCalendarSettings = $exportCalendarSettings"
 Write-Verbose "exportCustomizationSettings = $exportCustomizationSettings"
-Write-Verbose "ExportEmailTrackingSettings = $ExportEmailTrackingSettings"
+Write-Verbose "exportEmailTrackingSettings = $ExportEmailTrackingSettings"
 Write-Verbose "exportExternalApplications = $exportExternalApplications"
 Write-Verbose "exportGeneralSettings = $exportGeneralSettings"
 Write-Verbose "exportIsvConfig = $exportIsvConfig"
@@ -70,6 +72,27 @@ if ($updateVersion)
 	$versionNumber = $buildNumber.Substring($buildNumber.IndexOf("_") + 1)
 }
 
-& "$scriptPath\ps_modules\xRMCIFramework\ExportSolution.ps1"  -CrmConnectionString $crmConnectionString -SolutionName $solutionName -ExportManaged $exportManaged -ExportUnmanaged $exportUnmanaged -ExportSolutionOutputPath $outputPath -TargetVersion $targetVersion -UpdateVersion $updateVersion -RequiredVersion $versionNumber -ExportIncludeVersionInSolutionName $includeVersionInSolutionFile -ExportAutoNumberingSettings $exportAutoNumberingSettings -ExportCalendarSettings $exportCalendarSettings -ExportCustomizationSettings $exportCustomizationSettings -ExportEmailTrackingSettings $exportEmailTrackingSettings -ExportExternalApplications $exportExternalApplications -ExportGeneralSettings $exportGeneralSettings -ExportMarketingSettings $exportMarketingSettings -ExportOutlookSynchronizationSettings $exportOutlookSynchronizationSettings -ExportIsvConfig $exportIsvConfig -ExportRelationshipRoles $exportRelationshipRoles -ExportSales $exportSales -Timeout $crmConnectionTimeout
+& "$scriptPath\ps_modules\xRMCIFramework\ExportSolution.ps1" -CrmConnectionString $crmConnectionString `
+	-SolutionName $solutionName `
+	-ExportManaged $exportManaged `
+	-ExportUnmanaged $exportUnmanaged `
+	-ExportSolutionOutputPath $outputPath `
+	-TargetVersion $targetVersion `
+	-UpdateVersion $updateVersion `
+	-RequiredVersion $versionNumber `
+	-ExportIncludeVersionInSolutionName $includeVersionInSolutionFile `
+	-OnlyExportIfNewer:$onlyExportIfNewer `
+	-ExportAutoNumberingSettings $exportAutoNumberingSettings `
+	-ExportCalendarSettings $exportCalendarSettings `
+	-ExportCustomizationSettings $exportCustomizationSettings `
+	-ExportEmailTrackingSettings $exportEmailTrackingSettings `
+	-ExportExternalApplications $exportExternalApplications `
+	-ExportGeneralSettings $exportGeneralSettings `
+	-ExportMarketingSettings $exportMarketingSettings `
+	-ExportOutlookSynchronizationSettings $exportOutlookSynchronizationSettings `
+	-ExportIsvConfig $exportIsvConfig `
+	-ExportRelationshipRoles $exportRelationshipRoles `
+	-ExportSales $exportSales `
+	-Timeout $crmConnectionTimeout
 
 Write-Verbose 'Leaving MSCRMExportSolution.ps1'

--- a/CRM365/Xrm.Framework.CI/Xrm.Framework.CI.VSTS.BuildTasks/Tasks/MSCRMExportSolution/task.json
+++ b/CRM365/Xrm.Framework.CI/Xrm.Framework.CI.VSTS.BuildTasks/Tasks/MSCRMExportSolution/task.json
@@ -4,7 +4,7 @@
   "friendlyName": "MSCRM Export Solution",
   "description": "Exports a CRM Solution from the source CRM environment",
   "author": "Wael Hamze",
-  "helpMarkDown": "More information here: https://msdn.microsoft.com/en-us/library/microsoft.crm.sdk.messages.exportsolutionrequest.aspx",
+  "helpMarkDown": "[More information](https://msdn.microsoft.com/en-us/library/microsoft.crm.sdk.messages.exportsolutionrequest.aspx)",
   "category": "Build",
   "visibility": [
     "Build",
@@ -13,8 +13,8 @@
   "demands": [ ],
   "version": {
     "Major": "8",
-    "Minor": "1",
-    "Patch": "1"
+    "Minor": "2",
+    "Patch": "0"
   },
   "minimumAgentVersion": "1.95.0",
   "instanceNameFormat": "MSCRM Export Solution: $(solutionName)",
@@ -32,7 +32,7 @@
       "label": "CRM Connection String",
       "defaultValue": "",
       "required": true,
-      "helpMarkDown": "For more information on format: https://msdn.microsoft.com/en-gb/library/mt608573.aspx"
+      "helpMarkDown": "[Connection String Format](https://msdn.microsoft.com/en-US/library/mt608573.aspx)"
     },
     {
       "name": "solutionName",
@@ -64,7 +64,7 @@
       "label": "Target Version",
       "defaultValue": "",
       "required": false,
-      "helpMarkDown": "Check task help for more information"
+      "helpMarkDown": "Indicates the version that the exported solution will support. e.g. '8.0.0.0' or '8.1.0.0'"
     },
     {
       "name": "updateVersion",
@@ -72,7 +72,7 @@
       "label": "Update Version",
       "defaultValue": "false",
       "required": false,
-      "helpMarkDown": "Sets the solution version in the source environment to the build number. build number format must end with '_x.x.x.x' e.g. '$(BuildDefinitionName)_5.0.0$(Rev:.r)'"
+      "helpMarkDown": "Sets the solution version in the source environment to the build number. Build number format must end with '_x.x.x.x' e.g. '$(BuildDefinitionName)_5.0.0$(Rev:.r)'"
     },
     {
       "name": "includeVersionInSolutionFile",
@@ -83,17 +83,25 @@
       "helpMarkDown": "Set to true to include the version number in the generated solution file name"
     },
     {
+      "name": "onlyExportIfNewer",
+      "type": "boolean",
+      "label": "Export only if Version is Higher",
+      "defaultValue": "false",
+      "required": false,
+      "helpMarkDown": "If the Output Path already contains a solution export file, this will skip exporting the solution if the new version is not higher then the existing version. This can save you time if you export the same solution multiple times\n\nThis option will check for the version in the file name first; if there is no version in the file name it will read the version from the solution.xml inside the zip file"
+    },
+    {
       "name": "outputPath",
       "type": "filePath",
       "label": "Output Path",
-      "defaultValue": "$(build.binariesdirectory)",
+      "defaultValue": "$(Build.BinariesDirectory)",
       "required": true,
       "helpMarkDown": "The path on the agent machine where you want the solutions to be placed"
     },
     {
       "name": "crmConnectionTimeout",
       "type": "string",
-      "label": "Crm Connection Timeout",
+      "label": "CRM Connection Timeout",
       "defaultValue": "120",
       "required": false,
       "helpMarkDown": "The Crm connection timeout in seconds"
@@ -155,7 +163,7 @@
     {
       "name": "exportIsvConfig",
       "type": "boolean",
-      "label": "Export Isv Config",
+      "label": "Export ISV Config",
       "defaultValue": "false",
       "required": false,
       "helpMarkDown": "Check task help for more information",


### PR DESCRIPTION
This can save you time if you have a build process that's can execute multiple times and the solution version stays the same.

If this option is enabled the script will look in the output location if there is an earlier exported solution.
It will get the version from the file name if present (e.g. 'Solution_2_0_0_0.zip') or from inside the solution if not present (e.g. Solution.zip).
If the version of the solution to be exported is not higher the export will be skipped.

For comparison the version is cast to a .NET Version object. This makes sure that 12_0_0_0 is greater then 3_0_0_0 (which would be the case if you would use text comparison)