### PR TITLE
Retry to connect if CrmServiceClient is not ready

### DIFF
--- a/CRM365/Xrm.Framework.CI/Xrm.Framework.CI.PowerShell.Cmdlets/Xrm.Framework.CI.PowerShell.Cmdlets.csproj
+++ b/CRM365/Xrm.Framework.CI/Xrm.Framework.CI.PowerShell.Cmdlets/Xrm.Framework.CI.PowerShell.Cmdlets.csproj
@@ -61,7 +61,6 @@
     </Reference>
     <Reference Include="Microsoft.Xrm.Tooling.Connector, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CrmSdk.XrmTooling.CoreAssembly.8.2.0.5\lib\net452\Microsoft.Xrm.Tooling.Connector.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
@@ -145,7 +144,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>$(SolutionDir)\packages\NuGet.CommandLine.4.1.0\tools\NuGet.exe pack -sym $(ProjectDir)$(ProjectFileName) -Prop Configuration=$(ConfigurationName)</PostBuildEvent>
+    <PostBuildEvent>$(SolutionDir)\packages\NuGet.CommandLine.4.3.0\tools\NuGet.exe pack -sym $(ProjectDir)$(ProjectFileName) -Prop Configuration=$(ConfigurationName)</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/CRM365/Xrm.Framework.CI/Xrm.Framework.CI.PowerShell.Cmdlets/packages.config
+++ b/CRM365/Xrm.Framework.CI/Xrm.Framework.CI.PowerShell.Cmdlets/packages.config
@@ -1,9 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="8.2.0.2" targetFramework="net46" />
+  <package id="Microsoft.CrmSdk.CoreTools" version="8.2.0.5" targetFramework="net46" />
   <package id="Microsoft.CrmSdk.Deployment" version="8.2.0.2" targetFramework="net46" />
   <package id="Microsoft.CrmSdk.Workflow" version="8.2.0.2" targetFramework="net46" />
-  <package id="Microsoft.CrmSdk.CoreTools" version="8.2.0.5" targetFramework="net46" />
+  <package id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="8.2.0.5" targetFramework="net46" />
   <package id="Microsoft.IdentityModel" version="6.1.7600.16394" targetFramework="net452" />
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="2.22.302111727" targetFramework="net46" />
   <package id="Microsoft.PowerShell.5.ReferenceAssemblies" version="1.1.0" targetFramework="net46" />


### PR DESCRIPTION
Tried to solve #58
Not so elegant but it worked in our releases. Now I can successfully deploy big solution sets.
Also now users can see actual connection error message instead of Object reference not set to an instance of an object.