### PR TITLE
Adding Timeout parameter to MSCRM Package Deployer task

### DIFF
--- a/BuildTools/Xrm.CI.Framework.BuildTools/Tasks/MSCRMPackageDeployer/MSCRMPackageDeployer.ps1
+++ b/BuildTools/Xrm.CI.Framework.BuildTools/Tasks/MSCRMPackageDeployer/MSCRMPackageDeployer.ps1
@@ -11,6 +11,7 @@ $crmConnectionString = Get-VstsInput -Name crmConnectionString -Require
 $packageName = Get-VstsInput -Name packageName -Require
 $packageDirectory = Get-VstsInput -Name packageDirectory -Require
 $crmSdkVersion = Get-VstsInput -Name crmSdkVersion -Require
+$timeoutPD = Get-VstsInput -Name timeoutPD -Require
 
 #TFS Release Parameters
 $artifactsFolder = $env:AGENT_RELEASEDIRECTORY
@@ -21,6 +22,7 @@ Write-Verbose "packageName = $packageName"
 Write-Verbose "packageDirectory = $packageDirectory"
 Write-Verbose "artifactsFolder = $artifactsFolder"
 Write-Verbose "crmSdkVersion = $crmSdkVersion"
+Write-Verbose "timeoutPD = $timeoutPD"
 
 #Script Location
 $scriptPath = split-path -parent $MyInvocation.MyCommand.Definition
@@ -32,7 +34,7 @@ $PackageDeploymentPath = "$scriptPath\Lib\PackageDeployment\$crmSdkVersion"
 
 try
 {
-	& "$scriptPath\Lib\xRMCIFramework\$crmSdkVersion\DeployPackage.ps1" -CrmConnectionString $crmConnectionString -PackageName $packageName -PackageDirectory $packageDirectory -LogsDirectory $packageDirectory -PackageDeploymentPath $PackageDeploymentPath
+	& "$scriptPath\Lib\xRMCIFramework\$crmSdkVersion\DeployPackage.ps1" -CrmConnectionString $crmConnectionString -PackageName $packageName -PackageDirectory $packageDirectory -LogsDirectory $packageDirectory -PackageDeploymentPath $PackageDeploymentPath -Timeout $timeoutPD
 }
 finally
 {

--- a/BuildTools/Xrm.CI.Framework.BuildTools/Tasks/MSCRMPackageDeployer/task.json
+++ b/BuildTools/Xrm.CI.Framework.BuildTools/Tasks/MSCRMPackageDeployer/task.json
@@ -54,6 +54,14 @@
       "defaultValue": "$(System.DefaultWorkingDirectory)/<BuildName>/<ArtifactName>/<PackageFolder>",
       "required": false,
       "helpMarkDown": "The absolute path to the CRM Package folder on the release agent machine"
+    },
+    {
+      "name": "tmeoutPD",
+      "type": "string",
+      "label": "Package Deployment Timeout",
+      "defaultValue": "1:30:00",
+      "required": true,
+      "helpMarkDown": "The timespan notation for the timeout value of a package deployment operation. The format applied is '[d:]h:mm:ss', where d is optional For example: 1:30:00 means wait up to 1 hr and 30 mins for the package deployment operation to complete. 1:14:30:00 means wait up to 1 day, 14 hrs, and 30 mins for the package deployment operation to complete."
     }
   ],
   "execution": {

--- a/CRM365/Xrm.Framework.CI/Xrm.Framework.CI.PowerShell.Scripts/DeployPackage.ps1
+++ b/CRM365/Xrm.Framework.CI/Xrm.Framework.CI.PowerShell.Scripts/DeployPackage.ps1
@@ -6,7 +6,8 @@ param(
 [string]$CrmConnectionString,
 [string]$PackageName,
 [string]$PackageDirectory,
-[string]$LogsDirectory = ''
+[string]$LogsDirectory = '',
+[string]$Timeout = '1:30:00' #optional timeout for Import-CrmPackage, default to 1 hour and 20 min. See https://technet.microsoft.com/en-us/library/dn756301.aspx
 )
 
 $ErrorActionPreference = "Stop"
@@ -18,6 +19,7 @@ Write-Verbose "CrmConnectionString = $CrmConnectionString"
 Write-Verbose "PackageName = $PackageName"
 Write-Verbose "PackageDirectory = $PackageDirectory"
 Write-Verbose "LogsDirectory = $LogsDirectory"
+Write-Verbose "Timeout = $Timeout"
 
 #Script Location
 $scriptPath = split-path -parent $MyInvocation.MyCommand.Definition
@@ -48,6 +50,6 @@ $CRMConn = Get-CrmConnection -ConnectionString $CrmConnectionString -Verbose
 
 #Deploy Package
 
-Import-CrmPackage –CrmConnection $CRMConn –PackageDirectory $PackageDirectory –PackageName $PackageName -LogWriteDirectory $LogsDirectory -Verbose
+Import-CrmPackage –CrmConnection $CRMConn –PackageDirectory $PackageDirectory –PackageName $PackageName -LogWriteDirectory $LogsDirectory -Timeout $Timeout -Verbose 
 
 Write-Verbose 'Leaving DeployPackage.ps1'

--- a/CRM365/Xrm.Framework.CI/Xrm.Framework.CI.VSTS.BuildTasks/Tasks/MSCRMPackageDeployer/MSCRMPackageDeployer.ps1
+++ b/CRM365/Xrm.Framework.CI/Xrm.Framework.CI.VSTS.BuildTasks/Tasks/MSCRMPackageDeployer/MSCRMPackageDeployer.ps1
@@ -10,6 +10,7 @@ Write-Verbose 'Entering MSCRMPackageDeployer.ps1'
 $crmConnectionString = Get-VstsInput -Name crmConnectionString -Require
 $packageName = Get-VstsInput -Name packageName -Require
 $packageDirectory = Get-VstsInput -Name packageDirectory -Require
+$timeoutPD = Get-VstsInput -Name timeoutPD -Require
 
 #TFS Release Parameters
 $artifactsFolder = $env:AGENT_RELEASEDIRECTORY
@@ -19,6 +20,7 @@ Write-Verbose "crmConnectionString = $crmConnectionString"
 Write-Verbose "packageName = $packageName"
 Write-Verbose "packageDirectory = $packageDirectory"
 Write-Verbose "artifactsFolder = $artifactsFolder"
+Write-Verbose "timeoutPD = $timeoutPD"
 
 #Script Location
 $scriptPath = split-path -parent $MyInvocation.MyCommand.Definition
@@ -28,7 +30,7 @@ $LogFile = "$packageDirectory" +"\Microsoft.Xrm.Tooling.PackageDeployment-" + (G
 
 try
 {
-	& "$scriptPath\ps_modules\xRMCIFramework\DeployPackage.ps1" -CrmConnectionString $crmConnectionString -PackageName $packageName -PackageDirectory $packageDirectory -LogsDirectory $packageDirectory
+	& "$scriptPath\ps_modules\xRMCIFramework\DeployPackage.ps1" -CrmConnectionString $crmConnectionString -PackageName $packageName -PackageDirectory $packageDirectory -LogsDirectory $packageDirectory -Timeout $timeoutPD
 }
 finally
 {

--- a/CRM365/Xrm.Framework.CI/Xrm.Framework.CI.VSTS.BuildTasks/Tasks/MSCRMPackageDeployer/task.json
+++ b/CRM365/Xrm.Framework.CI/Xrm.Framework.CI.VSTS.BuildTasks/Tasks/MSCRMPackageDeployer/task.json
@@ -42,6 +42,14 @@
       "defaultValue": "$(System.DefaultWorkingDirectory)/<BuildName>/<ArtifactName>/<PackageFolder>",
       "required": false,
       "helpMarkDown": "The absolute path to the CRM Package folder on the release agent machine"
+    },
+    {
+      "name": "tmeoutPD",
+      "type": "string",
+      "label": "Package Deployment Timeout",
+      "defaultValue": "1:30:00",
+      "required": true,
+      "helpMarkDown": "The timespan notation for the timeout value of a package deployment operation. The format applied is '[d:]h:mm:ss', where d is optional For example: 1:30:00 means wait up to 1 hr and 30 mins for the package deployment operation to complete. 1:14:30:00 means wait up to 1 day, 14 hrs, and 30 mins for the package deployment operation to complete."
     }
   ],
   "execution": {


### PR DESCRIPTION
Per the issue #131 I submitted, this pull request attempts to add a Timeout parameter to the MSCRM Package Deployer task and pass it to Import-CrmPackage as described here: https://technet.microsoft.com/en-us/library/dn756301.aspx. I am not set up to unit test, so please review the changes closely. I did not add the parameter to the 8.2 version of the framework because I am not sure if it is available there.