### PR TITLE
resolve solution path in import script

### DIFF
--- a/MSDYNV9/Xrm.Framework.CI/Xrm.Framework.CI.PowerShell.Scripts/ImportSolution.ps1
+++ b/MSDYNV9/Xrm.Framework.CI/Xrm.Framework.CI.PowerShell.Scripts/ImportSolution.ps1
@@ -30,6 +30,9 @@ Write-Verbose "Importing CIToolkit: $xrmCIToolkit"
 Import-Module $xrmCIToolkit
 Write-Verbose "Imported CIToolkit"
 
+#Resolve solution path before handing off to other cmdlets
+$solutionFile = Resolve-Path $solutionFile
+
 Write-Verbose "solutionFile = $solutionFile"
 Write-Verbose "crmConnectionString = $crmConnectionString"
 Write-Verbose "override = $override"


### PR DESCRIPTION
Resolve the path for the solutionFile parameter in ImportSolution.ps1 so that a relative path can be passed in and used correctly by other cmdlets in script