### PR TITLE
Get-XrmPluginRegistration creates mapping with correct message name

### DIFF
--- a/MSDYNV9/Xrm.Framework.CI/Xrm.Framework.CI.PowerShell.Cmdlets/PluginRegistration/PluginRepository.cs
+++ b/MSDYNV9/Xrm.Framework.CI/Xrm.Framework.CI.PowerShell.Cmdlets/PluginRegistration/PluginRepository.cs
@@ -203,7 +203,7 @@ namespace Xrm.Framework.CI.PowerShell.Cmdlets.PluginRegistration
             Description = pluginStep.Description,
             FilteringAttributes = pluginStep.FilteringAttributes,
             ImpersonatingUserFullname = pluginStep.ImpersonatingUserId?.Name ?? string.Empty,
-            MessageName = sdkMessage?.CategoryName,
+            MessageName = sdkMessage?.Name,
             Mode = pluginStep.ModeEnum,
             PrimaryEntityName = filter.PrimaryObjectTypeCode,
             Rank = pluginStep.Rank,


### PR DESCRIPTION
The message name was set using the wrong field (CategoryName instead of Name). This becomes evident using the following steps:
- Register a plugin
- Add a step and select a message of an action (or something other than Create, Delete, Merge, Retrieve, RetrieveUnpublished, Rollup, Update, SendFromTemplate, GetValidStatusTransition, RouteTo, Recalculate, AddToQueue, ApplyRoutingRule, ApplyProfileRule or RemoveParent)
- Get the plugin mapping using CI365-Get-PluginRegistration

The mapping should contain the selected message, instead it is None or CustomOperation.

The used property should be 'Name' instead of 'CategoryName', because when the message id is retrieved, the name in de mapping is used to filter on Name again (PluginRepository.cs, line 42):
``` csharp
public Guid GetSdkMessageId(string name) =>
   (from a in context.SdkMessageSet
    where a.Name == name
    select a.Id).FirstOrDefault();
```