### PR TITLE
There may not be a SdkMessageFilter for a step. Don't lose these step…

### DIFF
--- a/MSDYNV9/Xrm.Framework.CI/Xrm.Framework.CI.PowerShell.Cmdlets/PluginRegistration/PluginRepository.cs
+++ b/MSDYNV9/Xrm.Framework.CI/Xrm.Framework.CI.PowerShell.Cmdlets/PluginRegistration/PluginRepository.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Xrm.Sdk;
 using Xrm.Framework.CI.Common.Entities;
 using Xrm.Framework.CI.PowerShell.Cmdlets.Common;
 
@@ -85,9 +86,10 @@ namespace Xrm.Framework.CI.PowerShell.Cmdlets.PluginRegistration
             var pluginTypes = (from plugins in context.PluginTypeSet
                                join steps in context.SdkMessageProcessingStepSet on plugins.PluginTypeId equals steps.EventHandler.Id
                                join message in context.SdkMessageSet on steps.SdkMessageId.Id equals message.SdkMessageId
-                               join filters in context.SdkMessageFilterSet on steps.SdkMessageFilterId.Id equals filters.Id
                                where plugins.PluginAssemblyId.Id == pluginAssembly.Id && plugins.IsWorkflowActivity == false
-                               select MapPluginObject(steps, message, filters, pluginStepImages, pluginAssemblyObject, plugins)).ToList();
+                               select MapPluginObject( 
+                                   steps, message, GetMessageFilter( context.SdkMessageFilterSet, steps.SdkMessageFilterId ), pluginStepImages, pluginAssemblyObject, plugins )
+                              ).ToList();
             var typesHasSteps = new HashSet<string>(pluginAssemblyObject.PluginTypes.Select(t => t.Name));
             var allPluginType = (from plugins in context.PluginTypeSet
                                  where plugins.PluginAssemblyId.Id == pluginAssembly.Id && plugins.IsWorkflowActivity == false //&& !typesHasSteps.Contains(plugins.Name)
@@ -99,7 +101,16 @@ namespace Xrm.Framework.CI.PowerShell.Cmdlets.PluginRegistration
             return pluginAssemblyObject;
         }
 
-        public Guid GetServiceEndpointId(string name) =>
+		private SdkMessageFilter GetMessageFilter( IQueryable<SdkMessageFilter> sdkMessageFilterSet, EntityReference sdkMessageFilterId )
+		{
+			if( sdkMessageFilterId == null )
+			{
+				return null;
+			}
+			return sdkMessageFilterSet.FirstOrDefault( f => f.Id == sdkMessageFilterId.Id );
+		}
+
+		public Guid GetServiceEndpointId(string name) =>
             (from a in context.ServiceEndpointSet
              where a.Name == name
              select a.Id).FirstOrDefault();
@@ -222,7 +233,7 @@ namespace Xrm.Framework.CI.PowerShell.Cmdlets.PluginRegistration
             ImpersonatingUserFullname = pluginStep.ImpersonatingUserId?.Name ?? string.Empty,
             MessageName = sdkMessage?.Name,
             Mode = pluginStep.ModeEnum,
-            PrimaryEntityName = filter.PrimaryObjectTypeCode,
+            PrimaryEntityName = filter?.PrimaryObjectTypeCode,
             Rank = pluginStep.Rank,
             Stage = pluginStep.StageEnum,
             AsyncAutoDelete = pluginStep.AsyncAutoDelete,


### PR DESCRIPTION
…s over the inner join.

Issue: a plugin step configured on a custom message, configured without primary entity or filtering attributes, does not create a message filter record. Because of the (inner) join 'on steps.SdkMessageFilterId.Id equals filters.Id' this this information was lost because it wasn't considered to have steps.