### PR TITLE
Fixed Import-XrmSolution Exception // Fixed Version Log output

### DIFF
--- a/MSDYNV9/Xrm.Framework.CI/Xrm.Framework.CI.Common/SolutionManagement/SolutionManager.cs
+++ b/MSDYNV9/Xrm.Framework.CI/Xrm.Framework.CI.Common/SolutionManagement/SolutionManager.cs
@@ -794,7 +794,7 @@ namespace Xrm.Framework.CI.Common
             }
             else
             {
-                Logger.LogInformation("{0} currently installed with version: {1}", info.UniqueName, info.Version);
+                Logger.LogInformation("{0} currently installed with version: {1}", info.UniqueName, baseSolution.Version);
             }
 
             if (baseSolution == null ||

--- a/MSDYNV9/Xrm.Framework.CI/Xrm.Framework.CI.Common/SolutionManagement/SolutionXml.cs
+++ b/MSDYNV9/Xrm.Framework.CI/Xrm.Framework.CI.Common/SolutionManagement/SolutionXml.cs
@@ -33,7 +33,7 @@ namespace Xrm.Framework.CI.Common
             {
                 using (ZipArchive solutionZip = ZipFile.Open(zipFile, ZipArchiveMode.Read))
                 {
-                    ZipArchiveEntry solutionEntry = solutionZip.GetEntry("Solution.xml");
+                    ZipArchiveEntry solutionEntry = solutionZip.GetEntry("solution.xml");
 
                     using (var reader = new StreamReader(solutionEntry.Open()))
                     {

--- a/MSDYNV9/Xrm.Framework.CI/Xrm.Framework.CI.Common/SolutionManagement/SolutionXml.cs
+++ b/MSDYNV9/Xrm.Framework.CI/Xrm.Framework.CI.Common/SolutionManagement/SolutionXml.cs
@@ -33,7 +33,7 @@ namespace Xrm.Framework.CI.Common
             {
                 using (ZipArchive solutionZip = ZipFile.Open(zipFile, ZipArchiveMode.Read))
                 {
-                    ZipArchiveEntry solutionEntry = solutionZip.GetEntry("solution.xml");
+                    var solutionEntry = solutionZip.Entries.First(e => e.Name.ToLower() == "solution.xml");
 
                     using (var reader = new StreamReader(solutionEntry.Open()))
                     {


### PR DESCRIPTION
The file is called "solution.xml" (at least in my solutions). As the `GetEntry` method seems to be case sensitive it will return null, which causes a `NullReferenceException` in line 38.

In addition the Log output "XXXXX currently installed with version: X.X.XX" was logging out the new version instead of the installed one.