### PR TITLE
Enable Application User connection strings

### DIFF
--- a/MSDYNV9/Xrm.Framework.CI/Xrm.Framework.CI.Common/CrmConnectionString.cs
+++ b/MSDYNV9/Xrm.Framework.CI/Xrm.Framework.CI.Common/CrmConnectionString.cs
@@ -1,0 +1,96 @@
+﻿using Microsoft.IdentityModel.Clients.ActiveDirectory;
+using Microsoft.Xrm.Tooling.Connector;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.ServiceModel.Description;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Xrm.Framework.CI.Common
+{
+    internal class CrmConnectionString
+    {
+        public Uri ServiceUri
+        {
+            get;
+            internal set;
+        }
+
+        public AuthenticationType AuthenticationType
+        {
+            get;
+            internal set;
+        }
+
+        public string ClientId
+        {
+            get;
+            internal set;
+        }
+
+        public string Password
+        {
+            get;
+            set;
+        }
+
+        public string UserId
+        {
+            get;
+            internal set;
+        }
+
+        public bool UseUniqueConnectionInstance
+        {
+            get;
+            internal set;
+        }
+
+        private CrmConnectionString(string serviceUri, string userName, string password, string authType, string requireNewInstance, string clientId)
+        {
+            this.ServiceUri = this.GetValidUri(serviceUri);
+            this.UserId = (!string.IsNullOrWhiteSpace(userName) ? userName : string.Empty);
+            this.Password = (!string.IsNullOrWhiteSpace(password) ? password : string.Empty);
+            this.ClientId = (!string.IsNullOrWhiteSpace(clientId) ? clientId : string.Empty);
+
+            if (!Enum.TryParse<AuthenticationType>(authType, out AuthenticationType authenticationType))
+            {
+                this.AuthenticationType = AuthenticationType.AD;
+            }
+            else
+            {
+                this.AuthenticationType = authenticationType;
+            }
+
+            bool.TryParse(requireNewInstance, out bool useUniqueConnectionInstance);
+            this.UseUniqueConnectionInstance = useUniqueConnectionInstance;
+        }
+
+        public static CrmConnectionString Parse(string connectionString)
+        {
+            var dictionary = connectionString.ToDictionary();
+            var serviceUri = dictionary.FirstNotNullOrEmpty<string>(new string[] { "ServiceUri", "Service Uri", "Url", "Server" });
+            var userName = dictionary.FirstNotNullOrEmpty<string>(new string[] { "UserName", "User Name", "UserId", "User Id" });
+            var password = dictionary.FirstNotNullOrEmpty<string>(new string[] { "Password" });
+            var authType = dictionary.FirstNotNullOrEmpty<string>(new string[] { "AuthType", "AuthenticationType" });
+            var requireNewInstance = dictionary.FirstNotNullOrEmpty<string>(new string[] { "RequireNewInstance" });
+            var clientId = dictionary.FirstNotNullOrEmpty<string>(new string[] { "ClientId", "AppId", "ApplicationId" });
+
+
+            return new CrmConnectionString(serviceUri, userName, password, authType, requireNewInstance, clientId);
+        }
+
+        private Uri GetValidUri(string uriSource)
+        { 
+            Uri validUriResult;
+            if (Uri.TryCreate(uriSource, UriKind.Absolute, out validUriResult))
+            {
+                return validUriResult;
+            }
+
+            return null;
+        }
+    }
+}

--- a/MSDYNV9/Xrm.Framework.CI/Xrm.Framework.CI.Common/OAuthClientCredentialsHook.cs
+++ b/MSDYNV9/Xrm.Framework.CI/Xrm.Framework.CI.Common/OAuthClientCredentialsHook.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
+using Microsoft.Xrm.Tooling.Connector;
+
+namespace Xrm.Framework.CI.Common
+{
+    internal class OAuthCredentialsHook : IOverrideAuthHookWrapper
+    {
+        private readonly string clientSecret;
+        private readonly string clientId;
+
+        public OAuthCredentialsHook(string clientId, string clientSecret)
+        {
+            this.clientId = clientId;
+            this.clientSecret = clientSecret;
+        }
+
+        public string GetAuthToken(Uri connectedUri)
+        {
+            var parameters = AuthenticationParameters.CreateFromResourceUrlAsync(connectedUri).Result;
+            var authContext = new AuthenticationContext(parameters.Authority, false);
+            return authContext.AcquireTokenAsync(parameters.Resource, new ClientCredential(this.clientId, this.clientSecret)).Result.AccessToken;
+        }
+    }
+}

--- a/MSDYNV9/Xrm.Framework.CI/Xrm.Framework.CI.Common/Xrm.Framework.CI.Common.csproj
+++ b/MSDYNV9/Xrm.Framework.CI/Xrm.Framework.CI.Common/Xrm.Framework.CI.Common.csproj
@@ -88,12 +88,14 @@
     <Compile Include="AsyncOperationManager.cs" />
     <Compile Include="Common\ReflectionLoader.cs" />
     <Compile Include="Common\XrmSolutionInfo.cs" />
+    <Compile Include="CrmConnectionString.cs" />
     <Compile Include="Data\ConfigurationMigrationManager.cs" />
     <Compile Include="Data\ConfigDataManager.cs" />
     <Compile Include="Entities\Entities.cs" />
     <Compile Include="Entities\OptionSets.cs" />
     <Compile Include="ImportJobManager.cs" />
     <Compile Include="Logging\ILogger.cs" />
+    <Compile Include="OAuthClientCredentialsHook.cs" />
     <Compile Include="PluginRegistration\Assembly.cs" />
     <Compile Include="PluginRegistration\AssemblyInfo.cs" />
     <Compile Include="PluginRegistration\Image.cs" />


### PR DESCRIPTION
In this pull request I enabled the possibility to sign in with an application user (Azure AD application). The connection string for S2S (server 2 server) flows looks like:

AuthType=OAuth;AppID=`<GUID>`;Url=`<DYNAMICSURL>`;password=`<SECRET>`

We really want this functionality because all our users are MFA enabled and we can't use them within our Azure DevOps build/release pipelines.