### PR TITLE
Correct Logging Issue with ExpandXrmCMData.cs

### DIFF
--- a/MSDYNV9/Xrm.Framework.CI/Xrm.Framework.CI.PowerShell.Cmdlets/ExpandXrmCMData.cs
+++ b/MSDYNV9/Xrm.Framework.CI/Xrm.Framework.CI.PowerShell.Cmdlets/ExpandXrmCMData.cs
@@ -51,7 +51,7 @@ namespace Xrm.Framework.CI.PowerShell.Cmdlets
         {
             base.ProcessRecord();
 
-            Logger.LogInformation("Expanding data file {0} to path: {0}", DataZip, Folder);
+            Logger.LogInformation("Expanding data file {0} to path: {1}", DataZip, Folder);
 
             ConfigurationMigrationManager manager = new ConfigurationMigrationManager(Logger);
 


### PR DESCRIPTION
Addressed an issue in the logging where the incorrect path is displayed when expanding configuration migration data.