### PR TITLE
Ability to split entity into seperate files for each record during Expand-XrmCMData

### DIFF
--- a/MSDYNV9/Xrm.Framework.CI/Xrm.Framework.CI.Common.IntegrationTests/ConfigurationMigrationTest.cs
+++ b/MSDYNV9/Xrm.Framework.CI/Xrm.Framework.CI.Common.IntegrationTests/ConfigurationMigrationTest.cs
@@ -24,7 +24,21 @@ namespace Xrm.Framework.CI.Common.IntegrationTests
 
             manager.ExpandData(dataZip, folder);
 
-            manager.SplitData(folder);
+            manager.SplitData(folder, splitRecords: false);
+        }
+
+        [TestMethod]
+        public void TestSplitData2()
+        {
+            string dataZip = @"C:\Temp\TestReferenceData\Extracted\data.zip";
+            string folder = @"C:\Temp\TestReferenceData\Unpacked";
+
+            TestLogger logger = new TestLogger();
+            ConfigurationMigrationManager manager = new ConfigurationMigrationManager(logger);
+
+            manager.ExpandData(dataZip, folder);
+
+            manager.SplitData(folder, splitRecords: true);
         }
 
         [TestMethod]

--- a/MSDYNV9/Xrm.Framework.CI/Xrm.Framework.CI.PowerShell.Cmdlets/ExpandXrmCMData.cs
+++ b/MSDYNV9/Xrm.Framework.CI/Xrm.Framework.CI.PowerShell.Cmdlets/ExpandXrmCMData.cs
@@ -43,7 +43,13 @@ namespace Xrm.Framework.CI.PowerShell.Cmdlets
         [Parameter(Mandatory = false)]
         public bool SortDataXmlFile { get; set; }
 
-        #endregion
+        /// <summary>
+        /// <para type="description">Splits the xml data into multiple files per record per entity</para>
+        /// </summary>
+        [Parameter(Mandatory = false)]
+        public bool SplitDataXmlFilePerEntityRecord { get; set; }
+
+        #endregion Parameters
 
         #region Process Record
 
@@ -64,12 +70,12 @@ namespace Xrm.Framework.CI.PowerShell.Cmdlets
 
             if (SplitDataXmlFile)
             {
-                manager.SplitData(Folder);
+                manager.SplitData(Folder, SplitDataXmlFilePerEntityRecord);
             }
 
             Logger.LogInformation("Exracting Data Completed");
         }
 
-        #endregion
+        #endregion Process Record
     }
 }

--- a/MSDYNV9/Xrm.Framework.CI/Xrm.Framework.CI.PowerShell.Scripts/ExtractCMData.ps1
+++ b/MSDYNV9/Xrm.Framework.CI/Xrm.Framework.CI.PowerShell.Scripts/ExtractCMData.ps1
@@ -9,7 +9,8 @@ param(
 [string]$extractFolder, #The absoluate path to folder for extracting the data zip file
 [bool]$sortExtractedData, #Set to true to sort the data.xml by record ids
 [bool]$splitExtractedData #Set to true to split the data.xml into multiple files per entity
-) 
+[bool]$splitExtractedDataPerEntityRecord #Set to true to split the data.xml into multiple files per entity and per record
+)
 
 $ErrorActionPreference = "Stop"
 $InformationPreference = "Continue"
@@ -29,10 +30,10 @@ Write-Verbose "Script Path: $scriptPath"
 
 #Load XrmCIFramework
 $xrmCIToolkit = $scriptPath + "\Xrm.Framework.CI.PowerShell.Cmdlets.dll"
-Write-Verbose "Importing CIToolkit: $xrmCIToolkit" 
+Write-Verbose "Importing CIToolkit: $xrmCIToolkit"
 Import-Module $xrmCIToolkit
 Write-Verbose "Imported CIToolkit"
 
-Expand-XrmCMData -DataZip "$dataFile" -Folder "$extractFolder" -SplitDataXmlFile $splitExtractedData -SortDataXmlFile $splitExtractedData
+Expand-XrmCMData -DataZip "$dataFile" -Folder "$extractFolder" -SplitDataXmlFile $splitExtractedData -SortDataXmlFile $splitExtractedData -SplitDataXmlFilePerEntityRecord $splitExtractedDataPerEntityRecord
 
 Write-Verbose 'Leaving ExtractCMData.ps1'


### PR DESCRIPTION
Might need some cleanup. Could be the default behaviour for the SplitDataXmlFile settings? Currently added new setting

Could move the {entityname}_data.xml to the entity folder.