### PR TITLE
Dont Delete Entities which are not in data.xml file

### DIFF
--- a/MSDYNV9/Xrm.Framework.CI/Xrm.Framework.CI.Common/Data/ConfigurationMigrationManager.cs
+++ b/MSDYNV9/Xrm.Framework.CI/Xrm.Framework.CI.Common/Data/ConfigurationMigrationManager.cs
@@ -283,19 +283,19 @@ namespace Xrm.Framework.CI.Common
                 }
             }
 
-            foreach(FileInfo entityInfo in dataInfo.GetFiles("*_data.xml"))
-            {
-                string entity = entityInfo.Name.Substring(0, entityInfo.Name.IndexOf("_data.xml"));
+//             foreach(FileInfo entityInfo in dataInfo.GetFiles("*_data.xml"))
+//             {
+//                 string entity = entityInfo.Name.Substring(0, entityInfo.Name.IndexOf("_data.xml"));
 
-                if (!entityNames.Contains(entity))
-                {
-                    Logger.LogInformation($"Deleting {entityInfo.Name} as it is not part of data.xml");
-                    entityInfo.Delete();
-                    Logger.LogInformation($"Deleted {entityInfo.Name}");
-                }
-            }
+//                 if (!entityNames.Contains(entity))
+//                 {
+//                     Logger.LogInformation($"Deleting {entityInfo.Name} as it is not part of data.xml");
+//                     entityInfo.Delete();
+//                     Logger.LogInformation($"Deleted {entityInfo.Name}");
+//                 }
+//             }
 
-            Logger.LogInformation("Removing entity records from data.xml");
+//             Logger.LogInformation("Removing entity records from data.xml");
 
             foreach (XElement entityNode in entitiesNode.Elements())
             {


### PR DESCRIPTION
Hi Wael,
We are using your extract config migration data task in Azure Devops pipeline. I observe that you are deleting the entities data which are not there in data.xml file. Can you comment these particular lines as we need all the entities data xml files which are created prior to the execution of the current even though the entity is not present in the data.xml file which is be exported using CMT tool. We are using this task and pushing the changes to our github for tracking of the files or entities xml's. So , by commenting these lines we will be able to retain the files and can use for source tracking inside our GitHub.
Need your help in this scenario.
If you have any other option to avoid deleting the previous files using your tasks, that's also fine for us to proceed.
Thank you.